### PR TITLE
Add interval and linked list algorithms

### DIFF
--- a/DotNetInterviewProblems/Problems/ActivitySelection.cs
+++ b/DotNetInterviewProblems/Problems/ActivitySelection.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Selects the maximum number of non-overlapping intervals by sorting
+    /// intervals by end time and greedily picking the earliest finishing one
+    /// that does not conflict with previously selected activities. Runs in
+    /// O(n log n) from the sort step.
+    /// </summary>
+    public static class ActivitySelection
+    {
+        public static int MaxNonOverlapping(int[][] intervals)
+        {
+            if (intervals == null || intervals.Length == 0) return 0;
+
+            var sorted = intervals.OrderBy(i => i[1]).ToArray();
+            int count = 0;
+            int lastEnd = int.MinValue;
+            foreach (var interval in sorted)
+            {
+                if (interval[0] >= lastEnd)
+                {
+                    count++;
+                    lastEnd = interval[1];
+                }
+            }
+            return count;
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/CycleDetection.cs
+++ b/DotNetInterviewProblems/Problems/CycleDetection.cs
@@ -1,0 +1,24 @@
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Detects if a singly linked list contains a cycle using the tortoise and
+    /// hare algorithm (Floyd's cycle detection). Runs in O(n) time and constant
+    /// space.
+    /// </summary>
+    public static class CycleDetection
+    {
+        public static bool HasCycle(ListNode? head)
+        {
+            if (head == null) return false;
+            var slow = head;
+            var fast = head.next;
+            while (fast != null && fast.next != null)
+            {
+                if (slow == fast) return true;
+                slow = slow!.next;
+                fast = fast.next.next;
+            }
+            return false;
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/LargestRectangleInHistogram.cs
+++ b/DotNetInterviewProblems/Problems/LargestRectangleInHistogram.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Calculates the largest rectangle area in a histogram using a monotonic
+    /// stack to track increasing bars. This achieves O(n) time by ensuring each
+    /// bar is pushed and popped at most once.
+    /// </summary>
+    public static class LargestRectangleInHistogram
+    {
+        public static int LargestRectangleArea(int[] heights)
+        {
+            if (heights == null || heights.Length == 0) return 0;
+            int maxArea = 0;
+            var stack = new Stack<int>();
+            int n = heights.Length;
+            for (int i = 0; i <= n; i++)
+            {
+                int h = i == n ? 0 : heights[i];
+                while (stack.Count > 0 && h < heights[stack.Peek()])
+                {
+                    int height = heights[stack.Pop()];
+                    int width = stack.Count == 0 ? i : i - stack.Peek() - 1;
+                    maxArea = Math.Max(maxArea, height * width);
+                }
+                stack.Push(i);
+            }
+            return maxArea;
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/ListNode.cs
+++ b/DotNetInterviewProblems/Problems/ListNode.cs
@@ -1,0 +1,16 @@
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Basic singly linked list node used by linked list problems.
+    /// </summary>
+    public class ListNode
+    {
+        public int val;
+        public ListNode? next;
+        public ListNode(int val = 0, ListNode? next = null)
+        {
+            this.val = val;
+            this.next = next;
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/MergeIntervals.cs
+++ b/DotNetInterviewProblems/Problems/MergeIntervals.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Merges overlapping intervals by first sorting them by start time and
+    /// then iteratively combining any that overlap. Runs in O(n log n) due to
+    /// the initial sort.
+    /// </summary>
+    public static class MergeIntervals
+    {
+        public static int[][] Merge(int[][] intervals)
+        {
+            if (intervals == null || intervals.Length == 0)
+                return Array.Empty<int[]>();
+
+            Array.Sort(intervals, (a, b) => a[0].CompareTo(b[0]));
+            var merged = new List<int[]> { intervals[0] };
+
+            foreach (var current in intervals.Skip(1))
+            {
+                var last = merged[^1];
+                if (current[0] <= last[1])
+                {
+                    last[1] = Math.Max(last[1], current[1]);
+                }
+                else
+                {
+                    merged.Add(new[] { current[0], current[1] });
+                }
+            }
+            return merged.ToArray();
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/ReverseLinkedList.cs
+++ b/DotNetInterviewProblems/Problems/ReverseLinkedList.cs
@@ -1,0 +1,23 @@
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Reverses a singly linked list iteratively in O(n) time by rewiring the
+    /// next pointers as it traverses the list.
+    /// </summary>
+    public static class ReverseLinkedList
+    {
+        public static ListNode? Reverse(ListNode? head)
+        {
+            ListNode? prev = null;
+            ListNode? current = head;
+            while (current != null)
+            {
+                var next = current.next;
+                current.next = prev;
+                prev = current;
+                current = next;
+            }
+            return prev;
+        }
+    }
+}

--- a/DotNetInterviewProblems/Problems/ValidParentheses.cs
+++ b/DotNetInterviewProblems/Problems/ValidParentheses.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotNetInterviewProblems.Problems
+{
+    /// <summary>
+    /// Determines if a string containing parentheses is valid. Uses a stack to
+    /// ensure every opening bracket has a corresponding closing bracket in the
+    /// correct order.
+    /// </summary>
+    public static class ValidParentheses
+    {
+        public static bool IsValid(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return true;
+
+            var stack = new Stack<char>();
+            foreach (char c in s)
+            {
+                if (c is '(' or '[' or '{')
+                {
+                    stack.Push(c);
+                }
+                else
+                {
+                    if (stack.Count == 0) return false;
+                    char open = stack.Pop();
+                    if ((c == ')' && open != '(') ||
+                        (c == ']' && open != '[') ||
+                        (c == '}' && open != '{'))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return stack.Count == 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement classic algorithms under `Problems` for more practice
  - MergeIntervals uses sorting and merging
  - ActivitySelection greedily selects non-overlapping intervals
  - ValidParentheses validates parentheses via a stack
  - LargestRectangleInHistogram computes area with a monotonic stack
  - ReverseLinkedList iteratively rewires nodes
  - CycleDetection uses Floyd's cycle detection
  - add a common `ListNode` class

## Testing
- `dotnet test DotNetInterviewProblems.Tests -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd95796d0832785e6475b5a36ee5a