### PR TITLE
Add .NET interview docs with more Q&A

### DIFF
--- a/DotNetInterviewDocs/ASPNetCore/README.md
+++ b/DotNetInterviewDocs/ASPNetCore/README.md
@@ -1,0 +1,24 @@
+# ASP.NET Core
+
+Questions covering ASP.NET Core with practical examples.
+
+### How does middleware work in ASP.NET Core?
+Middleware components are executed in a pipeline. Each component can handle or pass on the HTTP request. For instance, authentication middleware checks credentials before MVC middleware routes the request to a controller.
+
+### What is dependency injection and why is it used?
+ASP.NET Core has built-in dependency injection (DI). DI promotes loose coupling by providing required services to classes via constructors. This makes controllers easier to test and maintain.
+
+### What is the purpose of the `appsettings.json` file?
+It contains configuration values that are loaded at runtime. You can provide environment-specific settings using files like `appsettings.Development.json`.
+
+### How do you configure logging in ASP.NET Core?
+Use the logging APIs in `Program.cs` to add providers such as Console or Application Insights. Logging levels can be controlled in configuration.
+
+### What is the difference between `Use` and `Run` when adding middleware?
+`Use` can invoke the next delegate in the pipeline, while `Run` terminates the pipeline and prevents further middleware from executing.
+
+### What is the difference between `AddSingleton` and `AddTransient`?
+`AddSingleton` registers one instance of a service for the entire application lifetime, while `AddTransient` creates a new instance each time it is requested. Use singletons for shared, stateless services and transients for lightweight, disposable ones.
+
+### How do you secure an API using JWT authentication?
+Configure JWT bearer authentication in `Program.cs` and issue tokens to clients upon login. Clients include the token in the `Authorization` header so middleware can validate and authorize requests.

--- a/DotNetInterviewDocs/Basics/README.md
+++ b/DotNetInterviewDocs/Basics/README.md
@@ -1,0 +1,24 @@
+# Basics
+
+Sample questions covering fundamental .NET concepts.
+
+### What is the CLR?
+The Common Language Runtime (CLR) is the virtual machine component of .NET that manages code execution, memory, and type safety.
+
+### Explain boxing and unboxing.
+Boxing converts a value type to an object on the heap. Unboxing extracts the value type back from the object. Excessive boxing can lead to performance overhead.
+
+### How does garbage collection work in .NET?
+The CLR automatically frees memory for objects that are no longer referenced. The garbage collector runs periodically and compacts the heap to reduce fragmentation.
+
+### What are value types and reference types?
+Value types store data directly and are copied when passed to methods. Reference types store a pointer to data on the heap, so multiple references can point to the same object.
+
+### What is the difference between `ref` and `out` parameters?
+Both allow a method to modify the caller's variable. `ref` requires the variable to be initialized before passing, while `out` does not and must be assigned inside the method.
+
+### What are generics and why are they useful?
+Generics allow you to define type-safe data structures and methods. They reduce casting and increase code reusability, such as `List<T>` for strongly typed collections.
+
+### What is a delegate in C#?
+A delegate is a type that references a method with a specific signature. Delegates enable callback mechanisms and are the basis for events and LINQ projections.

--- a/DotNetInterviewDocs/OOP/README.md
+++ b/DotNetInterviewDocs/OOP/README.md
@@ -1,0 +1,24 @@
+# OOP
+
+Questions related to object-oriented programming in .NET with real-world examples.
+
+### What is inheritance in C#?
+Inheritance allows a class to derive from another, reusing its functionality. For example, `Controller` classes in ASP.NET Core inherit from `ControllerBase` to gain HTTP handling features.
+
+### Describe the difference between an interface and an abstract class.
+An interface defines a contract with no implementation, while an abstract class can provide some default implementation. Interfaces allow multiple inheritance of type, whereas classes do not.
+
+### What is encapsulation and why is it important?
+Encapsulation hides the internal state of an object and exposes behavior through methods or properties. This protects invariants and simplifies usage of the object.
+
+### Explain polymorphism with an example.
+Polymorphism lets you treat instances of different classes through a common interface or base class. A `List<Shape>` can contain `Circle` and `Rectangle` objects, each overriding a virtual `Draw` method.
+
+### What are the four pillars of OOP?
+Encapsulation, inheritance, polymorphism, and abstraction form the fundamental concepts of object-oriented programming.
+
+### What is abstraction?
+Abstraction focuses on exposing only essential features while hiding implementation details. An abstract base class can define abstract methods that derived classes implement.
+
+### When would you prefer composition over inheritance?
+Composition is favored when you want to combine behaviors without creating deep inheritance hierarchies. For example, a `Logger` service can be injected into multiple classes instead of inheriting from a common logging base class.

--- a/DotNetInterviewDocs/README.md
+++ b/DotNetInterviewDocs/README.md
@@ -1,0 +1,11 @@
+# DotNetInterviewDocs
+
+This directory contains theoretical .NET interview questions and answers organized by topic. Each subfolder focuses on a specific area of the .NET ecosystem and includes practical examples.
+
+Each topic contains multiple interview questions with concise answers and real-world examples.
+
+## Topics
+
+- [Basics](Basics/README.md) – core language and runtime questions
+- [OOP](OOP/README.md) – object-oriented programming concepts in .NET
+- [ASP.NET Core](ASPNetCore/README.md) – web development with ASP.NET Core

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository hosts a portfolio website and example .NET projects.
 
 - `EnterpriseApi` - ASP.NET Core Web API skeleton with EF Core and JWT authentication.
 - `DotNetInterviewProblems` - Console application with sample solutions for LeetCode problems.
+- [`DotNetInterviewDocs`](DotNetInterviewDocs/README.md) - Topic-wise interview questions and answers with real examples.
 
 Each project can be built with the .NET 8 SDK:
 


### PR DESCRIPTION
## Summary
- link to docs from root README
- create docs for Basics, OOP, and ASP.NET Core interview questions
- expand each topic with additional real-world examples and questions

## Testing
- `dotnet test DotNetInterviewProblems.Tests/DotNetInterviewProblems.Tests.csproj --no-build -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2fd7c608327b1729c42bea8d601